### PR TITLE
Remove: Dependency on Ringside Wide Font

### DIFF
--- a/frontend/src/styles/GlobalSiteStyles.js
+++ b/frontend/src/styles/GlobalSiteStyles.js
@@ -18,20 +18,6 @@ const GlobalSiteStyles = createGlobalStyle`
   */
 
   @font-face {
-    font-family: 'Ringside Wide A';
-    src: url('https://cdn.elizabethwarren.com/_public/fonts/RingsideWide-Light_Web.woff2') format('woff2'), url('https://cdn.elizabethwarren.com/_public/fonts/RingsideWide-Light_Web.woff') format('woff');
-    font-weight: 300;
-    font-style: normal;
-  }
-
-  @font-face {
-    font-family: 'Ringside Wide A';
-    src: url('https://cdn.elizabethwarren.com/_public/fonts/RingsideWide-Bold_Web.woff2') format('woff2'), url('https://cdn.elizabethwarren.com/_public/fonts/RingsideWide-Bold_Web.woff') format('woff');
-    font-weight: 700;
-    font-style: normal;
-  }
-
-  @font-face {
     font-family: 'Ringside Regular A';
     src: url('https://cdn.elizabethwarren.com/_public/fonts/RingsideRegular-Book_Web.woff2') format('woff2'), url('https://cdn.elizabethwarren.com/_public/fonts/RingsideRegular-Book_Web.woff') format('woff');
     font-weight: 400;

--- a/frontend/src/styles/scss/helpers/_fonts.scss
+++ b/frontend/src/styles/scss/helpers/_fonts.scss
@@ -28,18 +28,6 @@
   font-weight: 700;
 }
 
-@mixin wide-light {
-  font-family: "Ringside Wide A", "Ringside Wide B";
-  font-style: normal;
-  font-weight: 300;
-}
-
-@mixin wide-bold {
-  font-family: "Ringside Wide A", "Ringside Wide B";
-  font-style: normal;
-  font-weight: 700;
-}
-
 @mixin extra-wide-black {
   font-family: "Ringside Extra Wide SSm A", "Ringside Extra Wide SSm B";
   font-style: normal;

--- a/frontend/src/styles/scss/helpers/_type.scss
+++ b/frontend/src/styles/scss/helpers/_type.scss
@@ -79,7 +79,7 @@
   $color: $body-color,
   $sm-size: 12px,
   $lg-size: 12px) {
-  @include wide-bold;
+  @include extra-wide-black;
 
   color: $color;
   font-size: $sm-size;
@@ -96,7 +96,7 @@
   $color: $body-color,
   $sm-size: 12px,
   $lg-size: 12px) {
-  @include wide-light;
+  @include reg-book;
 
   color: $color;
   font-size: $sm-size;

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -60,16 +60,6 @@ const fonts = {
     font-style: normal;
     font-weight: 700;
   `,
-  wideLight: css`
-    font-family: 'Ringside Wide A', 'Ringside Wide B';
-    font-style: normal;
-    font-weight: 300;
-  `,
-  wideBold: css`
-    font-family: 'Ringside Wide A', 'Ringside Wide B';
-    font-style: normal;
-    font-weight: 700;
-  `,
   extraWide: css`
     font-family: 'Ringside Extra Wide SSm A', 'Ringside Extra Wide SSm B';
     font-style: normal;

--- a/frontend/src/utils/RichTextBlocks.js
+++ b/frontend/src/utils/RichTextBlocks.js
@@ -77,7 +77,8 @@ const Header4 = styled.h4`
 
 const Header5 = styled.h5`
   ${baseHeaderStyles}
-  ${({ theme }) => theme.fonts.wideBold}
+  ${({ theme }) => theme.fonts.extraWide}
+  font-weight: 700;
   font-size: 12px;
   letter-spacing: 0.86px;
   line-height: 1.17;


### PR DESCRIPTION
Desc: Due to low use of the license Ringside Wide font, we are removing the dependency on this across our web properties. 
Side note: I think the mixin etc css/scss files can be removed entirely from this repo potentially.